### PR TITLE
Allow passing Spark job properties when submitting it to DataProc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ credentials.json
 
 #Sonar Scaner
 .scannerwork
+
+# PyCharm IDE
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ clean:
 	-@rm -rf $(ROOT_PATH)/dist
 	-@rm -rf $(ROOT_PATH)/build
 
-
-
 release: clean
 ifndef VERSION
 	@echo "USAGE:\n make VERSION=XXX release"
@@ -26,7 +24,6 @@ endif
 	@git push origin HEAD
 	@echo "Pushing lib"
 	@python setup.py sdist upload -r pypi
-
 
 test:
 	@pytest

--- a/gcloud_utils/dataproc.py
+++ b/gcloud_utils/dataproc.py
@@ -122,7 +122,8 @@ class Dataproc(object):
 
         return result
 
-    def submit_job(self, cluster_name, gs_bucket, jar_paths, main_class, list_args):
+    def submit_job(self, cluster_name, gs_bucket, jar_paths, main_class, list_args,
+                   properties=None):
         """Submits the Spark job to the cluster, assuming jars at `jar_paths` list has
         already been uploaded to `gs_bucket`"""
 
@@ -149,6 +150,8 @@ class Dataproc(object):
                 }
             }
         }
+        if properties is not None:
+            job_details['job']['sparkJob']['properties'] = properties
 
         result = self.__client.projects().regions().jobs().submit(
             projectId=self.__project,

--- a/gcloud_utils/dataproc.py
+++ b/gcloud_utils/dataproc.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO,
 
 
 class Dataproc(object):
-    "Module to handle with Dataproc cluster"
+    """Module to handle with Dataproc cluster"""
     def __init__(self, project, region, http=None):
         self.__project = project
         self.__region = region
@@ -22,7 +22,7 @@ class Dataproc(object):
         self.__client = discovery.build('dataproc', 'v1', http=http)
 
     def list_clusters(self):
-        "List all clusters"
+        """List all clusters"""
         request = self.__client.projects().regions().clusters()
 
         result = request.list(projectId=self.__project, region=self.__region).execute()
@@ -66,8 +66,8 @@ class Dataproc(object):
 
         "Create a cluster"
         data_to_create = {
-            "projectId":self.__project,
-            "clusterName":name,
+            "projectId": self.__project,
+            "clusterName": name,
             "config": {
                 "configBucket": "",
                 "gceClusterConfig": {
@@ -111,7 +111,7 @@ class Dataproc(object):
         return result
 
     def delete_cluster(self, name):
-        "Delete cluster by name"
+        """Delete cluster by name"""
         result = self.__client.projects()\
             .regions()\
             .clusters()\
@@ -143,9 +143,9 @@ class Dataproc(object):
                     'jobId': job_id
                 },
                 'sparkJob': {
-                    'args':list_args,
-                    'mainClass':main_class,
-                    'jarFileUris':jar_files
+                    'args': list_args,
+                    'mainClass': main_class,
+                    'jarFileUris': jar_files
                 }
             }
         }

--- a/tests/test_dataproc.py
+++ b/tests/test_dataproc.py
@@ -4,6 +4,7 @@ from googleapiclient.http import HttpMockSequence
 from gcloud_utils import dataproc
 from freezegun import freeze_time
 
+
 class TestDataproc(unittest.TestCase):
     """Test Compute Class"""
 
@@ -89,8 +90,8 @@ class TestDataproc(unittest.TestCase):
         result = dataproc_test.delete_cluster("NAME")
         self.assertEqual(result['content-length'],'0')
 
-    @freeze_time("1994-04-27 12:00:01")
-    def test_submit_job_success(self):
+    @freeze_time('1994-04-27 12:00:01')
+    def test_submit_job_successfully(self):
         http_mocked = HttpMockSequence([
             ({'status': '200'}, open('tests/fixtures/dataproc/first_request.json', 'rb').read()),
             ({'status': '200'}, 'echo_request_body'),
@@ -99,14 +100,14 @@ class TestDataproc(unittest.TestCase):
             ({'status': '200'}, open('tests/fixtures/dataproc/job_status_done.json', 'rb').read())
         ])
 
-        dataproc_test = dataproc.Dataproc(project="project", region="region", http=http_mocked)
+        dataproc_test = dataproc.Dataproc(project='project', region='region', http=http_mocked)
         result = dataproc_test.submit_job(
-            "CLUSTER",
-            "BUCKET",
-            ["/path/to/jar/jarname.jar"],
-            "main",
-            ["arg1", "arg2"]
-            )
+            'CLUSTER',
+            'BUCKET',
+            ['/path/to/jar/jarname.jar'],
+            'main',
+            ['arg1', 'arg2']
+        )
 
         body_request_expected = {
             'projectId': 'project',
@@ -115,14 +116,53 @@ class TestDataproc(unittest.TestCase):
                 'sparkJob': {
                     'jarFileUris': ['/path/to/jar/jarname.jar'],
                     'mainClass': 'main',
-                    'args': ['arg1', 'arg2']},
+                    'args': ['arg1', 'arg2']
+                },
                 'reference': {'jobId': 'main_1994_04_27_12_00_01'}
             }
         }
 
         self.assertEqual(body_request_expected, result)
 
-    @freeze_time("1994-04-27 12:00:01")
+    @freeze_time('1994-04-27 12:00:01')
+    def test_submit_job_with_properties_successfully(self):
+        http_mocked = HttpMockSequence([
+            ({'status': '200'}, open('tests/fixtures/dataproc/first_request.json', 'rb').read()),
+            ({'status': '200'}, 'echo_request_body'),
+            ({'status': '200'}, open('tests/fixtures/dataproc/job_status_running.json', 'rb').read()),
+            ({'status': '200'}, open('tests/fixtures/dataproc/job_status_running.json', 'rb').read()),
+            ({'status': '200'}, open('tests/fixtures/dataproc/job_status_done.json', 'rb').read())
+        ])
+
+        dataproc_test = dataproc.Dataproc(project='project', region='region', http=http_mocked)
+        result = dataproc_test.submit_job(
+            'CLUSTER',
+            'BUCKET',
+            ['/path/to/jar/jarname.jar'],
+            'main',
+            ['arg1', 'arg2'],
+            {'a_property': 'a_property_value'}
+        )
+
+        body_request_expected = {
+            'projectId': 'project',
+            'job': {
+                'placement': {'clusterName': 'CLUSTER'},
+                'sparkJob': {
+                    'jarFileUris': ['/path/to/jar/jarname.jar'],
+                    'mainClass': 'main',
+                    'args': ['arg1', 'arg2'],
+                    'properties': {
+                        'a_property': 'a_property_value'
+                    }
+                },
+                'reference': {'jobId': 'main_1994_04_27_12_00_01'}
+            }
+        }
+
+        self.assertEqual(body_request_expected, result)
+
+    @freeze_time('1994-04-27 12:00:01')
     def test_submit_job_error(self):
         http_mocked = HttpMockSequence([
             ({'status': '200'}, open('tests/fixtures/dataproc/first_request.json', 'rb').read()),
@@ -132,7 +172,7 @@ class TestDataproc(unittest.TestCase):
             ({'status': '200'}, open('tests/fixtures/dataproc/job_status_done.json', 'rb').read())
         ])
 
-        dataproc_test = dataproc.Dataproc(project="project", region="region", http=http_mocked)
+        dataproc_test = dataproc.Dataproc(project='project', region='region', http=http_mocked)
 
         with self.assertRaises(Exception):
             dataproc_test.submit_job("", "", [""], "", [])


### PR DESCRIPTION
This PR makes it possible to call `Dataproc.submit_job()` passing a `properties` arguments (which is `None` by default to keep the method backwards compatible) to it.

These properties will be passed as the Spark job `properties` field that is described in [this link to the documentation](https://cloud.google.com/dataproc/docs/reference/rest/v1/SparkJob).