### PR TITLE
Add flag to ignore 'already exist' errors

### DIFF
--- a/gcloud_utils/bigquery/bigquery.py
+++ b/gcloud_utils/bigquery/bigquery.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from google.api_core.exceptions import NotFound, Conflict
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 
 from gcloud_utils.base_client import BaseClient

--- a/gcloud_utils/bigquery/bigquery.py
+++ b/gcloud_utils/bigquery/bigquery.py
@@ -97,21 +97,16 @@ class Bigquery(BaseClient):
     def create_dataset(self, dataset_id):
         """Create a dataset"""
         dataset = bigquery.Dataset(self._client.dataset(dataset_id))
-        return self._client.create_dataset(dataset)
+        return self._client.create_dataset(dataset, True)
 
     def create_table(self, dataset_id, table_id):
         """Create a table based on dataset"""
-        try:
-            self.create_dataset(dataset_id)
-        except Conflict as ex:
-            # Ignore database already exists conflict.
-            if ex.code != 409:
-                raise ex
+        self.create_dataset(dataset_id)
 
         dataset_ref = self._client.dataset(dataset_id)
         table_ref = dataset_ref.table(table_id)
         table = bigquery.Table(table_ref)
-        return self._client.create_table(table)
+        return self._client.create_table(table, True)
 
     def cloud_storage_to_table(self, bucket_name, filename,
                                dataset_id, table_id, job_config=None,


### PR DESCRIPTION
## Description

Fixes [#37](https://github.com/globocom/gcloud-utils/issues/37)

I changed bigquery.py in the bigquery package by putting a second parameter in _client's create_table method, this parameter is a bool where True is to ignore "already exists" errors when creating the table.
We can use it too in _client's create_dateset, enabling to remove the try except.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
