### PR TITLE
Fix increasing model versions on mlengine

### DIFF
--- a/gcloud_utils/ml_engine.py
+++ b/gcloud_utils/ml_engine.py
@@ -88,7 +88,7 @@ class MlEngine(object):
             )
 
         float_value = float(version[1:].replace("_", "."))
-        new_version = str(float_value + 0.1)
+        new_version = "{:.1f}".format(float_value + 0.1)
         return "v{}".format(new_version.replace(".", "_"))
 
     def __parent_model_name(self, model_name):


### PR DESCRIPTION
## Description

When increasing the model version on ml_engine.
if we have an old version with value of:
`version = 'v0_7' `
Then, the new version :
`new_version = '0.7999999999999999'`
But the expected result is:
`new_version = '0.8'`

Fixes # (issue)

## Type of change

Please mark options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] test_ml_engine.py test_create_new_model_version_4_5
- [X] test_ml_engine.py test_create_new_model_version_4_5

## Checklist:

- [X] I did follow the [contribution guidelines](https://github.com/globocom/gcloud-utils/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [X] Unit tests pass locally with my changes
